### PR TITLE
Comment out AppActivity#getColor(@ColorRes int resId) method to prevent app crash

### DIFF
--- a/qiitanium/src/main/java/com/ogaclejapan/qiitanium/presentation/activity/AppActivity.java
+++ b/qiitanium/src/main/java/com/ogaclejapan/qiitanium/presentation/activity/AppActivity.java
@@ -78,9 +78,9 @@ abstract class AppActivity extends Activity {
     return ResUtils.getInteger(this, resId);
   }
 
-  protected int getColor(@ColorRes int resId) {
-    return ResUtils.getColor(this, resId);
-  }
+//  protected int getColor(@ColorRes int resId) {
+//    return ResUtils.getColor(this, resId);
+//  }
 
   protected float getDimension(@DimenRes int resId) {
     return ResUtils.getDimension(this, resId);


### PR DESCRIPTION
This revision fixes #4.

I have commented out `AppActivity#getColor(@ColorRes int resId)` method to prevent app from crashing right after it launches on Nexus 5 Android M preview. (Not sure if it occurs in other environment as well.)

I'm guessing that a method with the same signature has been added to Context class in preview version so that it conflicts with the method above and causes app to crash.
- [Android L: LinkageError crashes application - Stack Overflow](http://stackoverflow.com/questions/24635115/android-l-linkageerror-crashes-application)
## info
- **I've only confirmed that the app does not crash on Nexus 5 Android M preview with this revison.**
